### PR TITLE
Fix: case insensitive recognition of SSH config values (e.g. "HostName" and "Hostname" should word)

### DIFF
--- a/sshconfig.go
+++ b/sshconfig.go
@@ -123,22 +123,22 @@ func parseSshConfig(path string) bool {
 			}
 		}
 		if len(parts) == 2 {
-			switch parts[0] {
-			case "HostName":
+			switch strings.ToLower(parts[0]) {
+			case "hostname":
 				update(func(s *Section) {
 					s.Hostname = parts[1]
 				})
-			case "Port":
+			case "port":
 				if p, err := strconv.Atoi(parts[1]); err == nil {
 					update(func(s *Section) {
 						s.Port = p
 					})
 				}
-			case "User":
+			case "user":
 				update(func(s *Section) {
 					s.User = parts[1]
 				})
-			case "IdentityFile":
+			case "identityfile":
 				update(func(s *Section) {
 					s.IdentityFile = parts[1]
 				})

--- a/sshconfig.go
+++ b/sshconfig.go
@@ -124,7 +124,7 @@ func parseSshConfig(path string) bool {
 		}
 		if len(parts) == 2 {
 			switch parts[0] {
-			case "Hostname":
+			case "HostName":
 				update(func(s *Section) {
 					s.Hostname = parts[1]
 				})


### PR DESCRIPTION
As written here:
http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man5/ssh_config.5?query=ssh_config&sec=5
the SSH config file option is called "HostName" and not "Hostname".