### PR TITLE
Fix issue for hosts where hostname -f fails

### DIFF
--- a/main.go
+++ b/main.go
@@ -155,7 +155,7 @@ func doHost(host string) {
 
 	for {
 		stats := Stats{At: time.Now()}
-		getAllStats(client, &stats)
+		getAllStats(host, client, &stats)
 		allStats.GetRing(stats.Hostname).Add(stats)
 		time.Sleep(DEFAULT_REFRESH * time.Second)
 	}

--- a/stats.go
+++ b/stats.go
@@ -47,18 +47,18 @@ type Stats struct {
 	MemCached  uint64
 }
 
-func getAllStats(client *ssh.Client, stats *Stats) {
-	getHostname(client, stats)
+func getAllStats(host string, client *ssh.Client, stats *Stats) {
+	getHostname(host, client, stats)
 	getLoad(client, stats)
 	getMemInfo(client, stats)
 }
 
-func getHostname(client *ssh.Client, stats *Stats) (err error) {
+func getHostname(host string, client *ssh.Client, stats *Stats) (err error) {
 	hostname, err := runCommand(client, "/bin/hostname -f")
 	if err != nil {
+		stats.Hostname = strings.TrimSpace(host)
 		return
 	}
-
 	stats.Hostname = strings.TrimSpace(hostname)
 	return
 }


### PR DESCRIPTION
This also resolves issues where hosts do not have a resolvable hostname, or if IPs are provided to the `rtop-vis` command.

@mdevan @sebeichholz
